### PR TITLE
Make compatible with 1.0.0+ versions of websocket client

### DIFF
--- a/gateway_addon/ipc.py
+++ b/gateway_addon/ipc.py
@@ -86,7 +86,7 @@ class IpcClient:
         while not self.registered:
             time.sleep(0.01)
 
-    def on_open(self):
+    def on_open(self, _):
         """Event handler for WebSocket opening."""
         if self.verbose:
             print('IpcClient: Connected to server, registering...')
@@ -102,7 +102,7 @@ class IpcClient:
             print('IpcClient: Failed to send message: {}'.format(e))
             return
 
-    def on_message(self, message):
+    def on_message(self, _, message):
         """
         Event handler for WebSocket messages.
 


### PR DESCRIPTION
With this change the supplied version of Python websocket client can be upgraded to above 1.0.0. 

https://github.com/websocket-client/websocket-client/issues/669

According to the authors the newer versions can give a speed boost of up to 100x.

Requirements could be set to v1.4.2, for example.

Seems to work on Candle 2.0.2 (64 bit), but not extensively tested yet.